### PR TITLE
Add a local integration test stack and gate integration tests behind …

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -2,7 +2,6 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: Aerospike, Inc.
-    copyright-year: '2024'
 
   paths:
     - '**/*.go'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     services:
       # Aerospike service container
       aerospike:
-        image: aerospike/aerospike-server-enterprise:8.0.0.7
+        image: aerospike/aerospike-server-enterprise:8.1.2.4
         ports:
           - 3000:3000
           - 3001:3001
@@ -26,12 +26,12 @@ jobs:
 
       # Fake GCS server
       fake-gcs-server:
-        image: fsouza/fake-gcs-server:1.52.2
+        image: fsouza/fake-gcs-server:1.56.1
         ports:
           - 4443:4443
         options: >-
           --entrypoint sh
-          fsouza/fake-gcs-server:1.52.2
+          fsouza/fake-gcs-server:1.56.1
           -c "/bin/fake-gcs-server -data /data -scheme http -public-host 127.0.0.1:4443"
 
     steps:
@@ -56,7 +56,7 @@ jobs:
           docker run -d \
             -p 10000:10000 \
             --name azurite \
-            mcr.microsoft.com/azure-storage/azurite:3.35.0 \
+            mcr.microsoft.com/azure-storage/azurite:3.37.0 \
             azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck \
           && until curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:10000/devstoreaccount1 | grep -qE "400|403"; do \
               echo "Waiting for Azurite..."; sleep 1; \
@@ -72,13 +72,17 @@ jobs:
           -e "MINIO_ACCESS_KEY=minioadmin" \
           -e "MINIO_SECRET_KEY=minioadminpassword" \
           -e "MINIO_BROWSER=off" \
-          minio/minio:latest server /data \
+          minio/minio:RELEASE.2025-09-07T16-13-09Z server /data \
           && until (curl -I http://127.0.0.1:9000/minio/health/live | grep "OK"); do echo "Waiting for MinIO server to be ready..."; sleep 3; done \
           && docker exec minio sh -c "mc alias set myminio http://127.0.0.1:9000 minioadmin minioadminpassword && mc mb myminio/backup && mc mb myminio/aerospike-backup \
           && mc anonymous set upload myminio/backup && mc anonymous set download myminio/backup && mc anonymous set public myminio/backup \
           && mc anonymous set upload myminio/aerospike-backup && mc anonymous set download myminio/aerospike-backup && mc anonymous set public myminio/aerospike-backup"
 
       - name: Test with coverage
+        env:
+          # Enables the tests that need the services started above. Without it
+          # they skip, and TestIntegrationEnabledInCI fails the build.
+          ABSCTL_INTEGRATION: "1"
         run: |
           make coverage
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ LICENSE = "Apache License 2.0"
 
 GO ?= $(shell which go || echo "/usr/local/go/bin/go")
 NFPM ?= $(shell which nfpm)
+COMPOSE ?= docker compose -f docker-compose.test.yaml
 OS ?= $(shell $(GO) env GOOS)
 ARCH ?= $(shell $(GO) env GOARCH)
 REGISTRY ?= "docker.io"
@@ -49,9 +50,31 @@ BINDIR ?= $(PREFIX)/bin
 DESTDIR ?=
 
 
+# Runs the unit tests. Tests that need a live Aerospike cluster, MinIO, Azurite
+# or fake-gcs-server skip themselves; use test-integration to include them.
 .PHONY: test
 test:
 	$(GOTEST) -parallel $(NPROC) -timeout=5m -count=1 -v ./...
+
+# Runs the full suite, including the tests that need external services.
+# Start them first with test-env-up.
+.PHONY: test-integration
+test-integration:
+	ABSCTL_INTEGRATION=1 $(GOTEST) -parallel $(NPROC) -timeout=5m -count=1 -v ./...
+
+# Starts the services the integration tests need and waits until they are ready.
+# minio-init is run separately because `up --wait` treats a container that exits,
+# even successfully, as a failure.
+.PHONY: test-env-up
+test-env-up:
+	$(COMPOSE) up -d --wait
+	$(COMPOSE) run --rm minio-init
+
+# --profile init is needed for down to also clean up the minio-init container,
+# since compose ignores services whose profile is not active.
+.PHONY: test-env-down
+test-env-down:
+	$(COMPOSE) --profile init down -v
 
 .PHONY: coverage
 coverage:

--- a/README.md
+++ b/README.md
@@ -265,6 +265,33 @@ make packages
 
 The generated packages and their `sha256` checksum files are written to the `target/` directory.
 
+### Running Tests
+
+```bash
+# Unit tests. No external services required.
+make test
+```
+
+Some tests exercise a live Aerospike cluster and the S3, GCS and Azure Blob
+backends. They skip unless `ABSCTL_INTEGRATION` is set, so `make test` passes on
+a fresh checkout. Each skip message names the service it needs.
+
+[docker-compose.test.yaml](docker-compose.test.yaml) provides those services —
+Aerospike, MinIO, Azurite and fake-gcs-server — using the same images as CI:
+
+```bash
+# Start the services and wait until they are ready
+make test-env-up
+
+# Run everything, including the integration tests
+make test-integration
+
+# Stop the services and delete their data
+make test-env-down
+```
+
+Coverage reported locally will be lower than the CI badge when these tests skip.
+
 ## Configuration
 
 Configuration can be supplied via command-line flags or a YAML file using `--config`.

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,88 @@
+# Services required by the integration tests.
+#
+# These mirror the containers started by .github/workflows/tests.yml, so that a
+# local run behaves the same as CI. Keep the image versions in sync with that
+# workflow: if they drift, a green local run stops predicting a green CI run.
+#
+#   make test-env-up
+#   make test-integration
+#   make test-env-down
+#
+# Ports are published on the host because the tests connect to 127.0.0.1.
+
+services:
+  # Aerospike Enterprise ships an evaluation feature key that covers a
+  # single-node cluster, so no license file is needed.
+  aerospike:
+    image: aerospike/aerospike-server-enterprise:8.1.2.4
+    container_name: absctl-aerospike
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+      - "3002:3002"
+    healthcheck:
+      test: ["CMD", "asinfo", "-v", "build"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: absctl-minio
+    command: server /data
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadminpassword
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadminpassword
+      MINIO_BROWSER: "off"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  # Creates the buckets the tests read and write. The workflow runs the same mc
+  # commands via docker exec; this uses the server image because it bundles mc,
+  # which keeps the file down to one MinIO version to pin.
+  #
+  # It sits behind a profile so that it is excluded from `up --wait`, which
+  # reports failure when a container exits even with status 0. `make test-env-up`
+  # runs it separately; if you start the stack by hand, run it yourself:
+  #
+  #   docker compose -f docker-compose.test.yaml run --rm minio-init
+  minio-init:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: absctl-minio-init
+    profiles: ["init"]
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - sh
+      - -c
+      - |
+        mc alias set local http://minio:9000 minioadmin minioadminpassword
+        mc mb --ignore-existing local/backup
+        mc mb --ignore-existing local/aerospike-backup
+        mc anonymous set public local/backup
+        mc anonymous set public local/aerospike-backup
+
+  # -public-host must match the endpoint the tests use, otherwise the server
+  # hands back download URLs pointing at a host the client cannot resolve.
+  fake-gcs-server:
+    image: fsouza/fake-gcs-server:1.56.1
+    container_name: absctl-fake-gcs
+    command: ["-data", "/data", "-scheme", "http", "-public-host", "127.0.0.1:4443"]
+    ports:
+      - "4443:4443"
+
+  # --skipApiVersionCheck keeps Azurite from rejecting newer Azure SDK releases.
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.37.0
+    container_name: absctl-azurite
+    command: azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+    ports:
+      - "10000:10000"

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Aerospike, Inc.
+// Copyright 2024-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 	"github.com/aerospike/absctl/internal/config"
 	"github.com/aerospike/absctl/internal/models"
 	"github.com/aerospike/absctl/internal/storage"
+	"github.com/aerospike/absctl/internal/testutil"
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go"
 	"github.com/aerospike/tools-common-go/client"
@@ -50,6 +51,7 @@ func testHostPort() *client.HostTLSPort {
 
 func Test_BackupWithState(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAerospike)
 
 	ctx := t.Context()
 	dir := path.Join(t.TempDir(), "plain")
@@ -103,6 +105,7 @@ func Test_BackupWithState(t *testing.T) {
 
 func Test_BackupEstimates(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAerospike)
 
 	ctx := t.Context()
 	hostPort := testHostPort()

--- a/internal/restore/restore_test.go
+++ b/internal/restore/restore_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Aerospike, Inc.
+// Copyright 2024-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"github.com/aerospike/absctl/internal/config"
 	"github.com/aerospike/absctl/internal/models"
 	"github.com/aerospike/absctl/internal/storage"
+	"github.com/aerospike/absctl/internal/testutil"
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go"
 	"github.com/aerospike/tools-common-go/client"
@@ -49,6 +50,7 @@ func testHostPort() *client.HostTLSPort {
 // Test_BackupRestore one test for both so we can restore from just backed-up files.
 func Test_BackupRestore(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAerospike)
 
 	ctx := t.Context()
 	dir := t.TempDir()

--- a/internal/storage/clients_test.go
+++ b/internal/storage/clients_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Aerospike, Inc.
+// Copyright 2024-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aerospike/absctl/internal/models"
+	"github.com/aerospike/absctl/internal/testutil"
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/tools-common-go/client"
 	"github.com/stretchr/testify/assert"
@@ -45,6 +46,7 @@ func testHostPort() *client.HostTLSPort {
 
 func TestClients_newAerospikeClient(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAerospike)
 
 	hostPort := testHostPort()
 	cfg := &client.AerospikeConfig{
@@ -97,9 +99,6 @@ func TestClients_newAerospikeClient(t *testing.T) {
 func TestClients_newS3Client(t *testing.T) {
 	t.Parallel()
 
-	err := createAwsCredentials()
-	require.NoError(t, err)
-
 	cfg := &models.AwsS3{
 		Region:   testS3Region,
 		Profile:  testS3Profile,
@@ -107,7 +106,7 @@ func TestClients_newS3Client(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	_, err = NewS3Client(ctx, cfg)
+	_, err := NewS3Client(ctx, cfg)
 	require.NoError(t, err)
 }
 

--- a/internal/storage/main_test.go
+++ b/internal/storage/main_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// awsCredentials is the shared credentials file the S3 tests authenticate with.
+// It matches the MinIO instance started by .github/workflows/tests.yml.
+const awsCredentials = `[minio]
+aws_access_key_id = minioadmin
+aws_secret_access_key = minioadminpassword`
+
+// TestMain points the AWS SDK at a throwaway credentials file. The tests need a
+// "minio" profile to exist, but must never write to the developer's real
+// ~/.aws/credentials. This runs before any test starts, so the environment is
+// set once for the whole package rather than by each test; t.Setenv is not an
+// option because these tests run in parallel.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "absctl-storage-test")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+
+	path := filepath.Join(dir, "credentials")
+	if err := os.WriteFile(path, []byte(awsCredentials), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write credentials file: %v\n", err)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
+
+	//nolint:usetesting // TestMain runs before the parallel tests, so t.Setenv is unavailable here.
+	if err := os.Setenv("AWS_SHARED_CREDENTIALS_FILE", path); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set credentials env: %v\n", err)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/internal/storage/readers_test.go
+++ b/internal/storage/readers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Aerospike, Inc.
+// Copyright 2024-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/aerospike/absctl/internal/config"
 	"github.com/aerospike/absctl/internal/models"
+	"github.com/aerospike/absctl/internal/testutil"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
@@ -107,9 +108,7 @@ func createTmpFileLocal(dir, fileName string) error {
 
 func TestNewS3Reader(t *testing.T) {
 	t.Parallel()
-
-	err := createAwsCredentials()
-	require.NoError(t, err)
+	testutil.RequireIntegration(t, testutil.ServiceS3)
 
 	dir := t.TempDir()
 	dir = strings.TrimPrefix(dir, "/")
@@ -184,6 +183,7 @@ func createTmpFileS3(ctx context.Context, client *s3.Client, dir, fileName strin
 
 func TestNewGcpReader(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceGCP)
 
 	err := createGcpBucket()
 	require.NoError(t, err)
@@ -257,6 +257,7 @@ func createTmpFileGcp(ctx context.Context, client *storage.Client, dir, fileName
 
 func TestNewAzureReader(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAzure)
 
 	err := createAzureContainer()
 	require.NoError(t, err)

--- a/internal/storage/writers_test.go
+++ b/internal/storage/writers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Aerospike, Inc.
+// Copyright 2024-2026 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/aerospike/absctl/internal/config"
 	"github.com/aerospike/absctl/internal/models"
+	"github.com/aerospike/absctl/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -105,9 +103,7 @@ func TestNewLocalWriter(t *testing.T) {
 
 func TestNewS3Writer(t *testing.T) {
 	t.Parallel()
-
-	err := createAwsCredentials()
-	require.NoError(t, err)
+	testutil.RequireIntegration(t, testutil.ServiceS3)
 
 	params := &config.BackupServiceConfig{
 		Backup: &models.Backup{
@@ -160,39 +156,9 @@ func TestNewS3Writer(t *testing.T) {
 	assert.Equal(t, testS3Type, writer.GetType())
 }
 
-func createAwsCredentials() error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("error getting home directory: %w", err)
-	}
-
-	awsDir := filepath.Join(home, ".aws")
-
-	err = os.MkdirAll(awsDir, 0o700)
-	if err != nil {
-		return fmt.Errorf("error creating .aws directory: %w", err)
-	}
-
-	filePath := filepath.Join(awsDir, "credentials")
-
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		credentialsFileBytes := []byte(`[minio]
-aws_access_key_id = minioadmin
-aws_secret_access_key = minioadminpassword`)
-
-		err = os.WriteFile(filePath, credentialsFileBytes, 0o600)
-		if err != nil {
-			return fmt.Errorf("error writing ~/.aws/credentials file: %w", err)
-		}
-
-		fmt.Println("Credentials file created successfully!")
-	}
-
-	return nil
-}
-
 func TestGcpWriter(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceGCP)
 
 	err := createGcpBucket()
 	require.NoError(t, err)
@@ -263,6 +229,7 @@ func createGcpBucket() error {
 
 func TestAzureWriter(t *testing.T) {
 	t.Parallel()
+	testutil.RequireIntegration(t, testutil.ServiceAzure)
 
 	err := createAzureContainer()
 	require.NoError(t, err)

--- a/internal/testutil/integration.go
+++ b/internal/testutil/integration.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil holds helpers shared between the package test suites.
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// EnvIntegration enables the tests that need the services defined in
+// .github/workflows/tests.yml. It is unset by default so that a clean
+// checkout can run `go test ./...` without any of them.
+const EnvIntegration = "ABSCTL_INTEGRATION"
+
+// Service descriptions used in skip messages, so a developer reading the
+// output knows exactly what to start.
+const (
+	ServiceAerospike = "an Aerospike cluster at 127.0.0.1:3000"
+	ServiceS3        = "MinIO at 127.0.0.1:9000"
+	ServiceGCP       = "fake-gcs-server at 127.0.0.1:4443"
+	ServiceAzure     = "Azurite at 127.0.0.1:10000"
+)
+
+// RequireIntegration skips the test unless integration testing is enabled.
+// service names the dependency the caller needs.
+func RequireIntegration(t *testing.T, service string) {
+	t.Helper()
+
+	if os.Getenv(EnvIntegration) == "" {
+		t.Skipf("skipping: requires %s; set %s=1 to run", service, EnvIntegration)
+	}
+}

--- a/internal/testutil/integration_test.go
+++ b/internal/testutil/integration_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIntegrationEnabledInCI guards against the integration suite being
+// silently disabled. Because RequireIntegration skips by default, dropping
+// EnvIntegration from the workflow would reduce CI to unit tests while still
+// reporting green. This fails loudly instead.
+func TestIntegrationEnabledInCI(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("CI") == "" {
+		t.Skip("not running in CI")
+	}
+
+	if os.Getenv(EnvIntegration) == "" {
+		t.Fatalf("%s must be set in CI, otherwise the integration tests are skipped silently", EnvIntegration)
+	}
+}


### PR DESCRIPTION
…ABSCTL_INTEGRATION

Introduces docker-compose.test.yaml with Aerospike, MinIO, fake-gcs-server, and Azurite, plus Makefile targets to start/stop/run integration tests. Integration tests now skip unless ABSCTL_INTEGRATION is set, and CI is updated to set it. Also isolates S3 test credentials via TestMain, updates test service image versions, and refreshes copyright years.