### PR TITLE
Add post-release verification workflows

### DIFF
--- a/.github/actions/seed-and-verify-aerospike/action.yml
+++ b/.github/actions/seed-and-verify-aerospike/action.yml
@@ -1,0 +1,108 @@
+name: Seed and verify Aerospike records
+description: >
+  Seeds a deterministic number of records into an Aerospike namespace, or counts existing
+  records, using the official aerospike/aerospike-tools image (aql for writes, asinfo for the
+  authoritative object count) rather than assuming aql/asinfo are present in whatever server
+  image is already running. Works against a bare host:port (local/docker mode) or, when
+  kubectl-namespace is set, against a cluster reached via a short-lived kubectl-run tools pod.
+
+inputs:
+  mode:
+    description: "'seed' to insert records, 'count' to read back the object count"
+    required: true
+  namespace:
+    description: Aerospike namespace to seed/count (e.g. test)
+    required: true
+  set-name:
+    description: Aerospike set name to use for seeded records
+    required: false
+    default: smoketest
+  record-count:
+    description: Number of records to seed (only used when mode=seed)
+    required: false
+    default: "1000"
+  host:
+    description: "Aerospike host:port to connect to (local/docker mode only)"
+    required: false
+    default: "127.0.0.1:3000"
+  kubectl-namespace:
+    description: If set, run against a cluster via a kubectl-run aerospike-tools pod in this k8s namespace instead of docker
+    required: false
+    default: ""
+  aerospike-k8s-host:
+    description: "Aerospike host:port reachable from inside the cluster (kubectl mode only)"
+    required: false
+    default: ""
+
+outputs:
+  record_count:
+    description: Object count reported by asinfo for the namespace (mode=count only)
+    value: ${{ steps.run.outputs.record_count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure tools pod (kubectl mode only)
+      if: inputs.kubectl-namespace != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        NS="${{ inputs.kubectl-namespace }}"
+        if ! kubectl get pod aerospike-tools-verify -n "$NS" >/dev/null 2>&1; then
+          kubectl run aerospike-tools-verify -n "$NS" \
+            --image=aerospike/aerospike-tools:latest \
+            --restart=Never \
+            --command -- sleep 3600
+        fi
+        kubectl wait --for=condition=Ready pod/aerospike-tools-verify -n "$NS" --timeout=120s
+
+    - name: Seed or count records
+      id: run
+      shell: bash
+      run: |
+        set -euo pipefail
+        MODE="${{ inputs.mode }}"
+        NS_AS="${{ inputs.namespace }}"
+        SET_NAME="${{ inputs.set-name }}"
+        COUNT="${{ inputs.record-count }}"
+        KUBECTL_NS="${{ inputs.kubectl-namespace }}"
+
+        if [ -n "$KUBECTL_NS" ]; then
+          AS_HOST="${{ inputs.aerospike-k8s-host }}"
+          run_aql() { kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- aql -h "$AS_HOST" "$@"; }
+          run_asinfo() { kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- asinfo -h "$AS_HOST" "$@"; }
+          cp_in() { kubectl cp "$1" "$KUBECTL_NS/aerospike-tools-verify:$2"; }
+        else
+          AS_HOST="${{ inputs.host }}"
+          run_aql() { docker run --rm --network host -v "$SEED_FILE_HOST:/tmp/seed.aql:ro" aerospike/aerospike-tools:latest aql -h "$AS_HOST" "$@"; }
+          run_asinfo() { docker run --rm --network host aerospike/aerospike-tools:latest asinfo -h "$AS_HOST" "$@"; }
+          cp_in() { :; } # no-op, docker mode mounts the file directly
+        fi
+
+        if [ "$MODE" = "seed" ]; then
+          SEED_FILE_HOST="$(mktemp)"
+          for i in $(seq 1 "$COUNT"); do
+            echo "insert into ${NS_AS}.${SET_NAME} (PK, val) values ('smoke-${i}', ${i})"
+          done > "$SEED_FILE_HOST"
+
+          if [ -n "$KUBECTL_NS" ]; then
+            cp_in "$SEED_FILE_HOST" "/tmp/seed.aql"
+            kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- aql -h "$AS_HOST" -f /tmp/seed.aql
+          else
+            run_aql -f /tmp/seed.aql
+          fi
+
+          echo "Seeded ${COUNT} records into ${NS_AS}.${SET_NAME}."
+        elif [ "$MODE" = "count" ]; then
+          RESPONSE="$(run_asinfo -v "namespace/${NS_AS}")"
+          OBJECTS="$(echo "$RESPONSE" | tr ';' '\n' | grep '^objects=' | cut -d= -f2)"
+          if [ -z "$OBJECTS" ]; then
+            echo "::error::Could not parse objects= from asinfo response: $RESPONSE"
+            exit 1
+          fi
+          echo "Namespace ${NS_AS} object count: ${OBJECTS}"
+          echo "record_count=${OBJECTS}" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Unknown mode '${MODE}' (expected 'seed' or 'count')"
+          exit 1
+        fi

--- a/.github/actions/wait-for-dockerhub-tag/action.yml
+++ b/.github/actions/wait-for-dockerhub-tag/action.yml
@@ -1,0 +1,56 @@
+name: Wait for DockerHub tag
+description: >
+  Polls DockerHub for a tag's arrival. DockerHub mirroring of a PROD-promoted image happens
+  externally and asynchronously via artifact-publisher (triggered by JFrog's own promotion
+  webhook), so this never hard-fails -- it reports found=true/false and lets the caller decide
+  whether that's a warning or a hard failure.
+
+inputs:
+  image:
+    description: DockerHub image, e.g. aerospike/aerospike-backup-service
+    required: true
+  tag:
+    description: Tag to wait for, e.g. 3.7.0 (without a leading "v")
+    required: true
+  max-attempts:
+    description: Maximum number of polling attempts
+    required: false
+    default: "15"
+  interval-seconds:
+    description: Seconds to wait between attempts
+    required: false
+    default: "60"
+
+outputs:
+  found:
+    description: "'true' if the tag was found within max-attempts, 'false' otherwise"
+    value: ${{ steps.poll.outputs.found }}
+
+runs:
+  using: composite
+  steps:
+    - name: Poll DockerHub for tag
+      id: poll
+      shell: bash
+      run: |
+        set -uo pipefail
+        IMAGE="${{ inputs.image }}"
+        TAG="${{ inputs.tag }}"
+        MAX_ATTEMPTS="${{ inputs.max-attempts }}"
+        INTERVAL="${{ inputs.interval-seconds }}"
+
+        found=false
+        for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+          status="$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${TAG}/")"
+          if [ "$status" = "200" ]; then
+            echo "DockerHub tag ${IMAGE}:${TAG} found on attempt ${attempt}/${MAX_ATTEMPTS}."
+            found=true
+            break
+          fi
+          echo "Attempt ${attempt}/${MAX_ATTEMPTS}: ${IMAGE}:${TAG} not found yet (HTTP ${status})."
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            sleep "$INTERVAL"
+          fi
+        done
+
+        echo "found=${found}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-release-verify-artifacts.yml
+++ b/.github/workflows/post-release-verify-artifacts.yml
@@ -1,0 +1,476 @@
+# Post-release verification: confirms a published version's artifacts are actually in place,
+# downloadable, correctly checksummed/signed, and installable. Targets the "database" JFrog
+# project (the shared-workflows pipeline) only -- see pre-release.yml/release.yml for the
+# pipeline this verifies. DockerHub checks are best-effort (see verify-dockerhub) since that
+# mirror is populated externally/asynchronously by artifact-publisher, outside this repo's
+# control. SBOM/attestation only exists for the container image today (confirmed by reading
+# aerospike/shared-workflows directly) -- .deb/.rpm have none, and this workflow says so
+# explicitly rather than silently skipping or faking that check. absctl has no Helm chart, so
+# there's no Helm-related check here (unlike aerospike-backup-service's equivalent workflow).
+
+name: Post-Release Verify Artifacts
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version to verify (must match a published GitHub Release, e.g. v1.3.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: absctl
+  DOCKERHUB_IMAGE: aerospike/absctl
+
+jobs:
+  verify-github-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Confirm release exists and is not a draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release view "${{ inputs.version }}" --json isDraft,tagName --repo "${{ github.repository }}" \
+            | tee release.json
+          if [ "$(jq -r '.isDraft' release.json)" = "true" ]; then
+            echo "::error::Release ${{ inputs.version }} is still a draft."
+            exit 1
+          fi
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p release-assets
+          gh release download "${{ inputs.version }}" --repo "${{ github.repository }}" --dir release-assets --clobber
+          echo "Downloaded assets:"
+          ls -la release-assets
+
+      - name: Import GPG public key
+        env:
+          GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+        run: echo "$GPG_PUBLIC_KEY" | gpg --import
+
+      - name: Verify DEB/RPM checksums and signatures
+        run: |
+          set -euo pipefail
+          cd release-assets
+          fail=0
+          shopt -s nullglob
+          for pkg in *.deb *.rpm; do
+            if [ ! -f "${pkg}.sha256" ]; then
+              echo "::error::Missing ${pkg}.sha256"
+              fail=1
+              continue
+            fi
+            computed="$(sha256sum "$pkg" | awk '{print $1}')"
+            recorded="$(tr -d '[:space:]' < "${pkg}.sha256")"
+            if [ "$computed" != "$recorded" ]; then
+              echo "::error::Checksum mismatch for ${pkg}: computed=${computed} recorded=${recorded}"
+              fail=1
+              continue
+            fi
+            echo "Checksum OK: ${pkg}"
+            if [ -f "${pkg}.sha256.asc" ]; then
+              if gpg --verify "${pkg}.sha256.asc" "${pkg}.sha256" 2>&1; then
+                echo "Signature OK: ${pkg}.sha256"
+              else
+                echo "::error::GPG signature verification failed for ${pkg}.sha256"
+                fail=1
+              fi
+            else
+              echo "::error::Missing ${pkg}.sha256.asc"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Write checksum summary for downstream jobs
+        run: |
+          cd release-assets
+          python3 - <<'EOF'
+          import glob, hashlib, json
+          out = {}
+          for f in glob.glob("*.deb") + glob.glob("*.rpm"):
+              h = hashlib.sha256()
+              with open(f, "rb") as fh:
+                  h.update(fh.read())
+              out[f] = h.hexdigest()
+          with open("../checksums.json", "w") as fh:
+              json.dump(out, fh, indent=2)
+          EOF
+          cat ../checksums.json
+
+      - name: Upload verified assets + checksums for downstream jobs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-assets
+          path: |
+            release-assets/
+            checksums.json
+          retention-days: 1
+
+  verify-jfrog-prod:
+    needs: [verify-github-release]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download verified checksums
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-assets
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Verify DEB/RPM present in JFrog PROD with matching checksums
+        env:
+          DEB_REPO: ${{ vars.JF_ARTIFACTORY_DEB_PROD }}
+          RPM_REPO: ${{ vars.JF_ARTIFACTORY_RPM_PROD }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          echo "Searching ${DEB_REPO} for version=${VERSION}..."
+          jf rt search "${DEB_REPO}/**" --props "version=${VERSION}" > deb.json
+          echo "Searching ${RPM_REPO} for version=${VERSION}..."
+          jf rt search "${RPM_REPO}/**" --props "version=${VERSION}" > rpm.json
+
+          for f in deb.json rpm.json; do
+            count="$(jq 'length' "$f")"
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No artifacts found in JFrog PROD for $f"
+              fail=1
+            else
+              echo "$f: found $count artifact(s)"
+            fi
+          done
+
+          jq -s 'add' deb.json rpm.json > all.json
+          python3 - <<'EOF'
+          import json, sys
+          jfrog = json.load(open("all.json"))
+          local = json.load(open("checksums.json"))
+          jfrog_by_name = {a["path"].rsplit("/", 1)[-1]: a.get("sha256", "") for a in jfrog}
+          mismatches = []
+          for name, sha in local.items():
+              jfrog_sha = jfrog_by_name.get(name)
+              if jfrog_sha is None:
+                  continue
+              if jfrog_sha != sha:
+                  mismatches.append((name, sha, jfrog_sha))
+          if mismatches:
+              for name, local_sha, jfrog_sha in mismatches:
+                  print(f"::error::Checksum mismatch between GitHub Release and JFrog PROD for {name}: github={local_sha} jfrog={jfrog_sha}")
+              sys.exit(1)
+          print("All cross-checked artifacts agree between GitHub Release and JFrog PROD.")
+          EOF
+
+          exit $fail
+
+      - name: Verify container image tag exists in JFrog PROD
+        env:
+          CONTAINER_REPO: ${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          TAG_NO_V="${VERSION#v}"
+          RESPONSE="$(jf rt curl "/api/docker/${CONTAINER_REPO}/v2/${{ env.IMAGE_NAME }}/tags/list")"
+          echo "$RESPONSE" | jq .
+          if echo "$RESPONSE" | jq -e --arg t "$VERSION" '.tags | index($t)' >/dev/null || \
+             echo "$RESPONSE" | jq -e --arg t "$TAG_NO_V" '.tags | index($t)' >/dev/null; then
+            echo "Container image tag found in ${CONTAINER_REPO}."
+          else
+            echo "::error::Neither '${VERSION}' nor '${TAG_NO_V}' found in ${CONTAINER_REPO} tag list."
+            exit 1
+          fi
+
+  verify-dockerhub:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Wait for DockerHub tag
+        id: wait
+        uses: ./.github/actions/wait-for-dockerhub-tag
+        with:
+          image: ${{ env.DOCKERHUB_IMAGE }}
+          tag: ${{ inputs.version }}
+        continue-on-error: true
+
+      - name: Report DockerHub status
+        run: |
+          if [ "${{ steps.wait.outputs.found }}" = "true" ]; then
+            docker buildx imagetools inspect --raw "docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}" | \
+              jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' | tee platforms.txt
+            for want in "linux/amd64" "linux/arm64"; do
+              grep -qx "$want" platforms.txt || echo "::warning::DockerHub manifest missing platform ${want}"
+            done
+            echo "### DockerHub: present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::DockerHub tag ${{ inputs.version }} not found for ${{ env.DOCKERHUB_IMAGE }} within the polling window. artifact-publisher mirroring is external/async -- re-run this workflow later to re-check. Not treating this as a failure."
+            echo "### DockerHub: NOT YET PRESENT (external, async) -- re-run later" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  verify-sbom-attestation:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Verify SLSA build-provenance attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          gh attestation verify "oci://${IMAGE_REF}" --owner aerospike
+
+      - name: Verify SBOM/provenance OCI referrers are present
+        run: |
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .SBOM}}' | tee sbom.json
+          if [ "$(cat sbom.json)" = "null" ] || [ -z "$(cat sbom.json)" ]; then
+            echo "::error::No SBOM referrer found for ${IMAGE_REF}"
+            exit 1
+          fi
+          echo "SBOM referrer present for ${IMAGE_REF}."
+
+      - name: Report N/A for RPM/DEB
+        run: |
+          {
+            echo "### SBOM / attestation coverage"
+            echo "| Artifact | SBOM/attestation |"
+            echo "| --- | --- |"
+            echo "| Docker image | verified (SPDX SBOM + SLSA attestation) |"
+            echo "| .deb / .rpm | N/A -- no SBOM or attestation is produced anywhere in the build/sign/deploy pipeline for these artifact types (confirmed gap, not a bug in this check) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  verify-oci-labels:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.version }}
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Inspect and verify required labels are present
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Config.Labels}}' | tee labels.json
+          fail=0
+          for key in title description documentation base.name vendor licenses; do
+            val="$(jq -r --arg k "org.opencontainers.image.${key}" '.[$k] // empty' labels.json)"
+            if [ -z "$val" ]; then
+              echo "::error::Missing or empty label org.opencontainers.image.${key}"
+              fail=1
+            else
+              echo "org.opencontainers.image.${key} = ${val}"
+            fi
+          done
+          exit $fail
+
+      - name: Cross-check base.name label against the real Dockerfile
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          label_base="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.base.name"')"
+          dockerfile_from="$(grep -E '^FROM' Dockerfile | tail -1 | awk '{print $2}')"
+          resolved_from="${dockerfile_from//\$\{REGISTRY\}/docker.io}"
+          echo "Label base.name:        ${label_base}"
+          echo "Dockerfile FROM (real): ${resolved_from}"
+          if [ "$label_base" != "$resolved_from" ]; then
+            echo "::warning::org.opencontainers.image.base.name ('${label_base}') does not match the Dockerfile's actual final-stage base image ('${resolved_from}'). Not failing this check -- a labeling fix, if needed, is a separate task."
+          else
+            echo "base.name label matches the Dockerfile's actual base image."
+          fi
+
+  package-install:
+    needs: [verify-github-release]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+            family: deb
+            distro_tag: ubuntu24.04
+            image: ubuntu:24.04
+            pkg_arch_token: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            family: deb
+            distro_tag: ubuntu24.04
+            image: ubuntu:24.04
+            pkg_arch_token: arm64
+          - runner: ubuntu-24.04
+            arch: amd64
+            family: rpm
+            distro_tag: amzn2023
+            image: amazonlinux:2023
+            pkg_arch_token: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            family: rpm
+            distro_tag: amzn2023
+            image: amazonlinux:2023
+            pkg_arch_token: aarch64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download verified assets
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Install and verify (one-shot CLI -- --version is sufficient)
+        run: |
+          set -euo pipefail
+          cd release-assets
+          # Both arch variants share the same distro_tag suffix (e.g. *_amd64_ubuntu24.04.deb and
+          # *_arm64_ubuntu24.04.deb both match "*ubuntu24.04.deb"), so filter by the arch token too.
+          pkg="$(ls -1 *.${{ matrix.family }} | grep "${{ matrix.distro_tag }}" | grep "${{ matrix.pkg_arch_token }}")"
+          echo "Testing package: ${pkg}"
+
+          docker run -d --name target --platform "linux/${{ matrix.arch }}" "${{ matrix.image }}" sleep infinity
+          docker cp "$pkg" target:/tmp/package.${{ matrix.family }}
+
+          if [ "${{ matrix.family }}" = "deb" ]; then
+            docker exec target sh -c "apt-get update && apt-get install -y /tmp/package.deb"
+          else
+            docker exec target sh -c "dnf install -y /tmp/package.rpm"
+          fi
+
+          version_output="$(docker exec target absctl --version)"
+          echo "Reported version: ${version_output}"
+          case "$version_output" in
+            *"${{ inputs.version }}"*) echo "Version matches." ;;
+            *) echo "::warning::Reported version '${version_output}' does not obviously contain '${{ inputs.version }}' -- confirm the exact --version output format." ;;
+          esac
+
+      - name: Teardown
+        if: always()
+        run: docker rm -f target || true
+
+  docker-image-install:
+    needs: [verify-jfrog-prod]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Pull image (DockerHub first, JFrog PROD fallback)
+        id: pull
+        run: |
+          set +e
+          if docker pull --platform "linux/${{ matrix.arch }}" "docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}"; then
+            echo "ref=docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DockerHub pull failed (likely still mirroring) -- falling back to JFrog PROD."
+            IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+            docker pull --platform "linux/${{ matrix.arch }}" "$IMAGE_REF"
+            echo "ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run and verify
+        run: |
+          docker run --rm --platform "linux/${{ matrix.arch }}" "${{ steps.pull.outputs.ref }}" --version
+
+  summary:
+    needs: [verify-github-release, verify-jfrog-prod, verify-dockerhub, verify-sbom-attestation, verify-oci-labels, package-install, docker-image-install]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Aggregate results
+        run: |
+          {
+            echo "### Post-Release Verification: ${{ inputs.version }}"
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| verify-github-release | ${{ needs.verify-github-release.result }} |"
+            echo "| verify-jfrog-prod | ${{ needs.verify-jfrog-prod.result }} |"
+            echo "| verify-dockerhub | ${{ needs.verify-dockerhub.result }} |"
+            echo "| verify-sbom-attestation | ${{ needs.verify-sbom-attestation.result }} |"
+            echo "| verify-oci-labels | ${{ needs.verify-oci-labels.result }} |"
+            echo "| package-install (matrix) | ${{ needs.package-install.result }} |"
+            echo "| docker-image-install (matrix) | ${{ needs.docker-image-install.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/post-release-verify-functional.yml
+++ b/.github/workflows/post-release-verify-functional.yml
@@ -1,0 +1,158 @@
+# Post-release functional smoke test: spins up Aerospike + MinIO, seeds real records, installs
+# the released absctl package and runs a real backup-to-MinIO then restore, verifying the record
+# count matches. absctl's released `backup`/`restore` commands talk directly to Aerospike +
+# storage -- they do not need aerospike-backup-service running (confirmed: the REST-client
+# `service` subcommand is disabled/unreleased, out of scope here). amd64 only -- architecture
+# coverage already lives in post-release-verify-artifacts.yml's install matrix.
+
+name: Post-Release Verify Functional
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version to smoke-test (e.g. v1.3.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RECORD_COUNT: 1000
+  NAMESPACE: test
+  BUCKET: absctl-smoke-test
+  S3_ACCESS_KEY: minioadmin
+  S3_SECRET_KEY: minioadminpassword
+
+jobs:
+  backup-restore-smoke-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Start Aerospike
+        run: |
+          docker run -d --name aerospike --network host \
+            aerospike/aerospike-server-enterprise:8.0.0.7
+          for i in $(seq 1 20); do
+            if docker exec aerospike asinfo -p 3000 -v build >/dev/null 2>&1; then break; fi
+            [ "$i" -eq 20 ] && { echo "::error::Aerospike never became ready"; docker logs aerospike; exit 1; }
+            sleep 3
+          done
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio --network host \
+            -e "MINIO_ROOT_USER=${{ env.S3_ACCESS_KEY }}" \
+            -e "MINIO_ROOT_PASSWORD=${{ env.S3_SECRET_KEY }}" \
+            -e "MINIO_BROWSER=off" \
+            minio/minio:latest server /data
+          for i in $(seq 1 20); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then break; fi
+            [ "$i" -eq 20 ] && { echo "::error::MinIO never became ready"; docker logs minio; exit 1; }
+            sleep 3
+          done
+          docker run --rm --network host minio/mc sh -c \
+            "mc alias set myminio http://127.0.0.1:9000 ${{ env.S3_ACCESS_KEY }} ${{ env.S3_SECRET_KEY }} && \
+             mc mb myminio/${{ env.BUCKET }} && mc anonymous set public myminio/${{ env.BUCKET }}"
+
+      - name: Seed records and verify seed count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: seed
+          namespace: ${{ env.NAMESPACE }}
+          record-count: ${{ env.RECORD_COUNT }}
+          host: 127.0.0.1:3000
+
+      - name: Confirm seeded count before proceeding
+        id: seed-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Fail fast if seeding itself didn't work
+        run: |
+          if [ "${{ steps.seed-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after seeding, got ${{ steps.seed-count.outputs.record_count }}"
+            exit 1
+          fi
+
+      - name: Download and install the released absctl package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "${{ inputs.version }}" --repo "${{ github.repository }}" \
+            --pattern '*amd64_ubuntu24.04.deb' --dir release-assets --clobber
+          pkg="$(ls -1 release-assets/*.deb | head -1)"
+          sudo apt-get update
+          sudo apt-get install -y "$pkg"
+          absctl --version
+
+      - name: Trigger backup
+        run: |
+          absctl backup -h 127.0.0.1:3000 -n "${{ env.NAMESPACE }}" \
+            --s3-bucket-name "${{ env.BUCKET }}" \
+            --s3-endpoint-override "http://127.0.0.1:9000" \
+            --s3-access-key-id "${{ env.S3_ACCESS_KEY }}" --s3-secret-access-key "${{ env.S3_SECRET_KEY }}" \
+            -d absctl-smoke-test/
+
+      - name: Verify backup files landed in MinIO
+        run: |
+          docker run --rm --network host minio/mc sh -c \
+            "mc alias set myminio http://127.0.0.1:9000 ${{ env.S3_ACCESS_KEY }} ${{ env.S3_SECRET_KEY }} && \
+             mc ls --recursive myminio/${{ env.BUCKET }}/absctl-smoke-test/" | tee minio-ls.txt
+          [ -s minio-ls.txt ] || { echo "::error::No objects found under absctl-smoke-test/ in MinIO after backup"; exit 1; }
+
+      - name: Truncate namespace before restore
+        run: |
+          docker run --rm --network host aerospike/aerospike-tools:latest \
+            asinfo -h 127.0.0.1:3000 -v "truncate-namespace:namespace=${{ env.NAMESPACE }}"
+
+      - name: Confirm namespace is empty before restore
+        id: pre-restore-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Fail if truncate didn't work
+        run: |
+          if [ "${{ steps.pre-restore-count.outputs.record_count }}" != "0" ]; then
+            echo "::error::Namespace still has ${{ steps.pre-restore-count.outputs.record_count }} records after truncate"
+            exit 1
+          fi
+
+      - name: Trigger restore
+        run: |
+          absctl restore -h 127.0.0.1:3000 -n "${{ env.NAMESPACE }}" \
+            --s3-bucket-name "${{ env.BUCKET }}" \
+            --s3-endpoint-override "http://127.0.0.1:9000" \
+            --s3-access-key-id "${{ env.S3_ACCESS_KEY }}" --s3-secret-access-key "${{ env.S3_SECRET_KEY }}" \
+            -d absctl-smoke-test/
+
+      - name: Verify record count matches the original seed
+        id: final-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Assert final count
+        run: |
+          if [ "${{ steps.final-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after restore, got ${{ steps.final-count.outputs.record_count }}"
+            exit 1
+          fi
+          echo "Backup/restore smoke test passed: ${{ env.RECORD_COUNT }} records survived a full backup+restore round trip."
+
+      - name: Teardown
+        if: always()
+        run: docker rm -f aerospike minio 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Adds `post-release-verify-artifacts.yml` and `post-release-verify-functional.yml` (plus their composite actions) as `workflow_dispatch`-triggered post-release checks.
- Verifies a published release's artifacts (GitHub Release, JFrog PROD in the `database` project, DockerHub), checksums/signatures, container SBOM/attestation and OCI labels, install-and-run across amd64/arm64, and a real Aerospike+MinIO backup/restore smoke test using the released `absctl` binary.
- Self-contained -- no dependency on the rest of `switch-to-sharedworkflows`. Landed as its own PR because GitHub only allows dispatching `workflow_dispatch` workflows that exist on the default branch.

## Test plan
- [ ] Merge this PR
- [ ] Dispatch each workflow with a real released version and confirm expected results (JFrog-`database`-scoped checks will only pass for a version actually released through the new pipeline; GitHub Release / DockerHub checks should pass for any real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)